### PR TITLE
fix(core): cannot move interval to active context

### DIFF
--- a/core/context_interval.go
+++ b/core/context_interval.go
@@ -118,7 +118,11 @@ func (session *Session) EditContextInterval(ctxId string, intervalId string, sta
 
 func (session *Session) MoveIntervalById(idSrc string, idTarget string, intervalId string) error {
 	state := session.State
-	if err := session.ValidateActiveContext(idTarget); err != nil {
+	if err := session.ValidateContextsExist(idSrc, idTarget); err != nil {
+		return err
+	}
+
+	if err := session.ValidateActiveInterval(idSrc, intervalId); err != nil {
 		return err
 	}
 

--- a/core/context_interval_test.go
+++ b/core/context_interval_test.go
@@ -11,12 +11,12 @@ import (
 func TestDeleteInterval(t *testing.T) {
 	session := CreateTestSession()
 
-	assert.Len(t, session.State.Contexts[TEST_ID].Intervals, 2)
+	assert.Len(t, session.State.Contexts[TEST_ID].Intervals, 3)
 	assert.Equal(t, session.State.Contexts[TEST_ID].Duration, 2*time.Hour)
 
 	err := session.DeleteInterval(TEST_ID, TEST_INTERVAL_ID)
 	assert.NoError(t, err)
-	assert.Len(t, session.State.Contexts[TEST_ID].Intervals, 1)
+	assert.Len(t, session.State.Contexts[TEST_ID].Intervals, 2)
 	assert.Equal(t, session.State.Contexts[TEST_ID].Duration, 1*time.Hour)
 
 }
@@ -66,8 +66,8 @@ func TestGetActiveIntervals(t *testing.T) {
 	active, err := session.GetActiveIntervals(TEST_ID)
 
 	assert.NoError(t, err)
-	assert.Len(t, session.State.Contexts[TEST_ID].Intervals, 4)
-	assert.Len(t, active, 2)
+	assert.Len(t, session.State.Contexts[TEST_ID].Intervals, 5)
+	assert.Len(t, active, 3)
 	assert.Contains(t, active, "active1")
 	assert.Contains(t, active, "active2")
 
@@ -86,7 +86,7 @@ func TestGetActiveIntervalsNoActiveIntervals(t *testing.T) {
 
 	active, err := session.GetActiveIntervals(TEST_ID)
 	assert.NoError(t, err)
-	assert.Len(t, active, 0)
+	assert.Len(t, active, 1)
 }
 
 func TestGetActiveIntervl(t *testing.T) {
@@ -96,7 +96,7 @@ func TestGetActiveIntervl(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, interval)
 
-	assert.Len(t, session.State.Contexts[TEST_ID].Intervals, 2)
+	assert.Len(t, session.State.Contexts[TEST_ID].Intervals, 3)
 	assert.Contains(t, session.State.Contexts[TEST_ID].Intervals, TEST_INTERVAL_ID)
 	assert.Contains(t, session.State.Contexts[TEST_ID].Intervals, TEST_INTERVAL_2_ID)
 }
@@ -173,12 +173,26 @@ func TestGetIntervalsByDateCropEndToCurrentDay(t *testing.T) {
 func TestMoveInterval(t *testing.T) {
 	session := CreateTestSession()
 
-	assert.Len(t, session.MustGetCtx(TEST_ID).Intervals, 2)
+	assert.Len(t, session.MustGetCtx(TEST_ID).Intervals, 3)
 	assert.Len(t, session.MustGetCtx(TEST_ID_2).Intervals, 2)
 	session.MoveIntervalById(TEST_ID, TEST_ID_2, TEST_INTERVAL_ID)
 
-	assert.Len(t, session.MustGetCtx(TEST_ID).Intervals, 1)
+	assert.Len(t, session.MustGetCtx(TEST_ID).Intervals, 2)
 	assert.Len(t, session.MustGetCtx(TEST_ID_2).Intervals, 3)
+}
+
+func TestMoveActiveInterval(t *testing.T) {
+	session := CreateTestSession()
+
+	assert.Len(t, session.MustGetCtx(TEST_ID).Intervals, 3)
+	assert.Len(t, session.MustGetCtx(TEST_ID_2).Intervals, 2)
+	err := session.MoveIntervalById(TEST_ID, TEST_ID_2, TEST_INTERVAL_3_ID)
+
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "interval is active")
+
+	assert.Len(t, session.MustGetCtx(TEST_ID).Intervals, 3)
+	assert.Len(t, session.MustGetCtx(TEST_ID_2).Intervals, 2)
 }
 
 func TestErrOnEditCurrentContextInterval(t *testing.T) {

--- a/core/context_test.go
+++ b/core/context_test.go
@@ -53,7 +53,7 @@ func TestMergeContext(t *testing.T) {
 	err := session.MergeContext(TEST_ID_2, TEST_ID)
 	assert.NoError(t, err)
 	assert.Len(t, session.State.Contexts, 1)
-	assert.Len(t, session.State.Contexts[TEST_ID].Intervals, 4)
+	assert.Len(t, session.State.Contexts[TEST_ID].Intervals, 5)
 	assert.Len(t, session.State.Contexts[TEST_ID].Labels, 4)
 	assert.Equal(t, session.State.Contexts[TEST_ID].Duration, 4*time.Hour)
 }

--- a/core/context_validation.go
+++ b/core/context_validation.go
@@ -33,20 +33,20 @@ func (session *Session) ValidateContextExists(id string) error {
 	return nil
 }
 
+func (session *Session) ValidateContextsExist(ids ...string) error {
+	for _, id := range ids {
+		if err := session.ValidateContextExists(id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (session *Session) ValidateContextAlreadyExists(id string) error {
 	if _, ok := session.State.Contexts[id]; ok {
 		return errors.New("context already exists")
 	}
 	return nil
-}
-
-func (session *Session) ValidateContextsExist(ids ...string) error {
-	errs := []error{}
-	for _, id := range ids {
-		errs = append(errs, session.ValidateContextExists(id))
-	}
-
-	return errors.Join(errs...)
 }
 
 func (session *Session) ValidateIntervalExists(ctxId, id string) error {
@@ -55,6 +55,18 @@ func (session *Session) ValidateIntervalExists(ctxId, id string) error {
 		return nil
 	}
 	return errors.New("interval does not exist")
+}
+
+func (session *Session) ValidateActiveInterval(ctxId, id string) error {
+	if err := session.ValidateIntervalExists(ctxId, id); err != nil {
+		return err
+	}
+	interval := session.State.Contexts[ctxId].Intervals[id]
+	if interval.IsActive() {
+		return errors.New("interval is active")
+	}
+
+	return nil
 }
 
 func IsValidDescription(description string) error {

--- a/core/context_validation_test.go
+++ b/core/context_validation_test.go
@@ -1,0 +1,32 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateContextsExists(t *testing.T) {
+	session := CreateTestSession()
+	session.Free()
+	assert.NoError(t, session.ValidateContextsExist(TEST_ID, TEST_ID_2))
+	assert.Error(t, session.ValidateContextsExist(TEST_ID, TEST_ID_2, "test333"))
+
+}
+
+func TestValidateActiveInterval(t *testing.T) {
+	session := CreateTestSession()
+	session.CreateIfNotExistsAndSwitch("new-ctx", "test")
+
+	for k, _ := range session.State.Contexts["new-ctx"].Intervals {
+		err := session.ValidateActiveInterval("new-ctx", k)
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "interval is active")
+	}
+
+	session.Free()
+
+	for k, _ := range session.State.Contexts["new-ctx"].Intervals {
+		assert.NoError(t, session.ValidateActiveInterval("new-ctx", k))
+	}
+}

--- a/core/interval.go
+++ b/core/interval.go
@@ -13,3 +13,7 @@ type Interval struct {
 	Duration time.Duration     `json:"duration"`
 	Labels   []string          `json:"labels"`
 }
+
+func (interval *Interval) IsActive() bool {
+	return interval.End.Time.IsZero()
+}

--- a/core/test_helpers.go
+++ b/core/test_helpers.go
@@ -10,6 +10,7 @@ var TEST_ID = "test-context"
 var TEST_ID_2 = "test-context-2"
 var TEST_INTERVAL_ID = "test-interval-1"
 var TEST_INTERVAL_2_ID = "test-interval-2"
+var TEST_INTERVAL_3_ID = "test-interval-3"
 
 type TestTimeProvider struct {
 	currentTime time.Time
@@ -53,6 +54,12 @@ func CreateTestSession() *Session {
 							Id:       "test-interval-2",
 							Start:    ctxtime.ZonedTime{Time: dt.Add(1 * time.Hour), Timezone: "UTC"},
 							End:      ctxtime.ZonedTime{Time: dt.Add(3 * time.Hour), Timezone: "UTC"},
+							Duration: 1 * time.Hour,
+						},
+						"test-interval-3": {
+							Id:       "test-interval-2",
+							Start:    ctxtime.ZonedTime{Time: dt.Add(1 * time.Hour), Timezone: "UTC"},
+							End:      ctxtime.ZonedTime{Time: time.Time{}, Timezone: "UTC"},
 							Duration: 1 * time.Hour,
 						},
 					},


### PR DESCRIPTION
New validation flow:
- validate if source context exists
- validate if target context exists
- validate if interval is inactive